### PR TITLE
[orchagent] Use appropriate NextHopKey constructor

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2383,7 +2383,16 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             */
             else if (ol_nextHops.getSize() == 1)
             {
-                NextHopKey nexthop(ol_nextHops.to_string());
+                NextHopKey nexthop;
+                bool overlay_nh = ol_nextHops.is_overlay_nexthop();
+                if (overlay_nh)
+                {
+                    nexthop = NextHopKey(ol_nextHops.to_string(), overlay_nh);
+                }
+                else
+                {
+                    nexthop = NextHopKey(ol_nextHops.to_string());
+                }
 
                 if (nexthop.label_stack.getSize() &&
                     (m_neighOrch->getNextHopRefCount(nexthop) == 0))


### PR DESCRIPTION
**What I did**

Added a check to determine if next hop group is overlay before calling the appropriate NextHopKey constructor.

**Why I did it**

Swss container was failing when disabling an interface because the wrong NextHopKey constructor was called (during route deletion in routeorch.cpp) causing orchagent to throw an exception and stop.

**How I verified it**

Disabled an interface, swss container did not crash
