### PR TITLE
[neighsyncd] Allow creation of neighbors with link-local addresses

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -73,9 +73,6 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ":";
 
     nl_addr2str(rtnl_neigh_get_dst(neigh), ipStr, MAX_ADDR_SIZE);
-    /* Ignore IPv6 link-local addresses as neighbors */
-    if (family == IPV6_NAME && IN6_IS_ADDR_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
-        return;
     /* Ignore IPv6 multicast link-local addresses as neighbors */
     if (family == IPV6_NAME && IN6_IS_ADDR_MC_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
         return;


### PR DESCRIPTION
**What I did**

Removed the if statement that was preventing neighsyncd from adding neighbors with link local IPv6 addresses

**Why I did it**

This is required for ISIS, as it creates next hops with link-local addresses

**How I verified it**

Verified in system test
