### PR TITLE
[orchagent] Refactor neighorch nexthop map and refactor labeled next …

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -389,14 +389,14 @@ bool NeighOrch::removeNextHop(NextHopKey nexthop)
 
     gFgNhgOrch->invalidNextHopInNextHopGroup(nexthop);
 
-    if (m_syncdNextHops[nexthop].ref_count > 0)
+    if (m_syncdNextHops.at(nexthop).ref_count > 0)
     {
         SWSS_LOG_ERROR("Failed to remove still referenced next hop %s",
                        nexthop.to_string().c_str());
         return false;
     }
 
-    sai_object_id_t next_hop_id = m_syncdNextHops[nexthop].next_hop_id;
+    sai_object_id_t next_hop_id = m_syncdNextHops.at(nexthop).next_hop_id;
     sai_status_t status = sai_next_hop_api->remove_next_hop(next_hop_id);
 
     /*
@@ -432,9 +432,7 @@ bool NeighOrch::removeOverlayNextHop(const NextHopKey &nexthop)
 {
     SWSS_LOG_ENTER();
 
-    assert(hasNextHop(nexthop));
-
-    if (m_syncdNextHops[nexthop].ref_count > 0)
+    if (m_syncdNextHops.at(nexthop).ref_count > 0)
     {
         SWSS_LOG_ERROR("Failed to remove still referenced next hop %s on %s",
                    nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
@@ -447,26 +445,22 @@ bool NeighOrch::removeOverlayNextHop(const NextHopKey &nexthop)
 
 sai_object_id_t NeighOrch::getNextHopId(const NextHopKey &nexthop)
 {
-    assert(hasNextHop(nexthop));
-    return m_syncdNextHops[nexthop].next_hop_id;
+    return m_syncdNextHops.at(nexthop).next_hop_id;
 }
 
 int NeighOrch::getNextHopRefCount(const NextHopKey &nexthop)
 {
-    assert(hasNextHop(nexthop));
-    return m_syncdNextHops[nexthop].ref_count;
+    return m_syncdNextHops.at(nexthop).ref_count;
 }
 
 void NeighOrch::increaseNextHopRefCount(const NextHopKey &nexthop)
 {
-    assert(hasNextHop(nexthop));
-    m_syncdNextHops[nexthop].ref_count ++;
+    m_syncdNextHops.at(nexthop).ref_count ++;
 }
 
 void NeighOrch::decreaseNextHopRefCount(const NextHopKey &nexthop)
 {
-    assert(hasNextHop(nexthop));
-    m_syncdNextHops[nexthop].ref_count --;
+    m_syncdNextHops.at(nexthop).ref_count --;
 }
 
 bool NeighOrch::getNeighborEntry(const NextHopKey &nexthop, NeighborEntry &neighborEntry, MacAddress &macAddress)
@@ -786,7 +780,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
         return true;
     }
 
-    if (m_syncdNextHops[nexthop].ref_count > 0)
+    if (m_syncdNextHops.at(nexthop).ref_count > 0)
     {
         SWSS_LOG_INFO("Failed to remove still referenced neighbor %s on %s",
                       m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str());

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2490,22 +2490,25 @@ bool RouteOrch::removeOverlayNextHops(sai_object_id_t vrf_id, const NextHopGroup
     SWSS_LOG_NOTICE("Remove overlay Nexthop %s", ol_nextHops.to_string().c_str());
     for (auto &tunnel_nh : ol_nextHops.getNextHops())
     {
-        if (!m_neighOrch->getNextHopRefCount(tunnel_nh))
+        if (m_neighOrch->hasNextHop(tunnel_nh))
         {
-            if(!m_neighOrch->removeTunnelNextHop(tunnel_nh))
+            if (!m_neighOrch->getNextHopRefCount(tunnel_nh))
             {
-                SWSS_LOG_ERROR("Tunnel Nexthop %s delete failed", ol_nextHops.to_string().c_str());
-            }
-            else
-            {
-                m_neighOrch->removeOverlayNextHop(tunnel_nh);
-                SWSS_LOG_INFO("Tunnel Nexthop %s delete success", ol_nextHops.to_string().c_str());
-                SWSS_LOG_INFO("delete remote vtep %s", tunnel_nh.to_string(true).c_str());
-                status = deleteRemoteVtep(vrf_id, tunnel_nh);
-                if (status == false)
+                if(!m_neighOrch->removeTunnelNextHop(tunnel_nh))
                 {
-                    SWSS_LOG_ERROR("Failed to delete remote vtep %s ecmp", tunnel_nh.to_string(true).c_str());
-                    return false;
+                    SWSS_LOG_ERROR("Tunnel Nexthop %s delete failed", ol_nextHops.to_string().c_str());
+                }
+                else
+                {
+                    m_neighOrch->removeOverlayNextHop(tunnel_nh);
+                    SWSS_LOG_INFO("Tunnel Nexthop %s delete success", ol_nextHops.to_string().c_str());
+                    SWSS_LOG_INFO("delete remote vtep %s", tunnel_nh.to_string(true).c_str());
+                    status = deleteRemoteVtep(vrf_id, tunnel_nh);
+                    if (status == false)
+                    {
+                        SWSS_LOG_ERROR("Failed to delete remote vtep %s ecmp", tunnel_nh.to_string(true).c_str());
+                        return false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
…hop desync

Signed-off-by: Marius Supuran <Marius.Supuran@metaswitch.com>

**What I did**

* Changed neighorch nexthop map to use .at() instead of operator[]
* Added check to avoid exceptions thrown by the .at() function
* Moved the next hop removal from ~NextHopGroupMember to desync()

**Why I did it**

* With asserts being compiled out, using operator[] instead of .at() with maps could lead to inserting new elements
* Some checks are now required, as .at() can throw exceptions
* Moved next hop removal to avoid accidental calls at object destruction

**How I verified it**

* Verified with system tests
