### PR TITLE
Fix non-overlay NHG keys

### DIFF
--- a/orchagent/nexthopgroupkey.h
+++ b/orchagent/nexthopgroupkey.h
@@ -27,7 +27,8 @@ public:
         }
     }
 
-    NextHopGroupKey(const std::string &nexthops, const std::string& weights = "")
+    NextHopGroupKey(const std::string &nexthops, const std::string& weights = "") :
+        m_overlay_nexthops(false)
     {
         std::vector<std::string> nhv = tokenize(nexthops, NHG_DELIMITER);
         std::vector<std::string> wtv = tokenize(weights, NHG_DELIMITER);


### PR DESCRIPTION
**What I did**
Initialized the overlay property of the NHG key to `false` when it's not an overlay NHG key.

**Why I did it**
Leaving the field uninitialized would cause the property to not be initialized properly - it would contain trash value.

**How I verified it**

**Details if related**
