### PR TITLE
[orchagent] New version of the copy function also uses address mask

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1155,7 +1155,7 @@ void IntfsOrch::addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix)
     sai_route_entry_t unicast_route_entry;
     unicast_route_entry.switch_id = gSwitchId;
     unicast_route_entry.vr_id = vrf_id;
-    copy(unicast_route_entry.destination, ip_prefix.getIp(), ip_prefix.getMask());
+    copy(unicast_route_entry.destination, ip_prefix);
 
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
@@ -1195,7 +1195,7 @@ void IntfsOrch::removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_pref
     sai_route_entry_t unicast_route_entry;
     unicast_route_entry.switch_id = gSwitchId;
     unicast_route_entry.vr_id = vrf_id;
-    copy(unicast_route_entry.destination, ip_prefix.getIp());
+    copy(unicast_route_entry.destination, ip_prefix);
 
     sai_status_t status = sai_route_api->remove_route_entry(&unicast_route_entry);
     if (status != SAI_STATUS_SUCCESS)
@@ -1204,7 +1204,7 @@ void IntfsOrch::removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_pref
         throw runtime_error("Failed to remove IP2me route.");
     }
 
-    SWSS_LOG_NOTICE("Remove packet action trap route ip:%s", ip_prefix.getIp().to_string().c_str());
+    SWSS_LOG_NOTICE("Remove packet action trap route ip:%s, mask:%s", ip_prefix.getIp().to_string().c_str(), ip_prefix.getMask().to_string().c_str());
 
     if (unicast_route_entry.destination.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
     {

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1155,7 +1155,7 @@ void IntfsOrch::addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix)
     sai_route_entry_t unicast_route_entry;
     unicast_route_entry.switch_id = gSwitchId;
     unicast_route_entry.vr_id = vrf_id;
-    copy(unicast_route_entry.destination, ip_prefix.getIp());
+    copy(unicast_route_entry.destination, ip_prefix.getIp(), ip_prefix.getMask());
 
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
@@ -1178,7 +1178,7 @@ void IntfsOrch::addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix)
         throw runtime_error("Failed to create IP2me route.");
     }
 
-    SWSS_LOG_NOTICE("Create IP2me route ip:%s", ip_prefix.getIp().to_string().c_str());
+    SWSS_LOG_NOTICE("Create IP2me route ip:%s mask:%s", ip_prefix.getIp().to_string().c_str(), ip_prefix.getMask().to_string().c_str());
 
     if (unicast_route_entry.destination.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
     {

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -76,6 +76,28 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src)
     return dst;
 }
 
+inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src, const IpAddress& mask)
+{
+    auto sip = src.getIp();
+    auto msk = mask.getIp();
+    switch(sip.family)
+    {
+        case AF_INET:
+            dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+            dst.addr.ip4 = sip.ip_addr.ipv4_addr;
+            dst.mask.ip4 = msk.ip_addr.ipv4_addr;
+            break;
+        case AF_INET6:
+            dst.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
+            memcpy(dst.addr.ip6, sip.ip_addr.ipv6_addr, 16);
+            memcpy(dst.mask.ip6, msk.ip_addr.ipv6_addr, 16);
+            break;
+        default:
+            throw std::logic_error("Invalid family");
+    }
+    return dst;
+}
+
 inline static sai_ip_prefix_t& subnet(sai_ip_prefix_t& dst, const sai_ip_prefix_t& src)
 {
     dst.addr_family = src.addr_family;

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -76,28 +76,6 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src)
     return dst;
 }
 
-inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src, const IpAddress& mask)
-{
-    auto sip = src.getIp();
-    auto msk = mask.getIp();
-    switch(sip.family)
-    {
-        case AF_INET:
-            dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
-            dst.addr.ip4 = sip.ip_addr.ipv4_addr;
-            dst.mask.ip4 = msk.ip_addr.ipv4_addr;
-            break;
-        case AF_INET6:
-            dst.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
-            memcpy(dst.addr.ip6, sip.ip_addr.ipv6_addr, 16);
-            memcpy(dst.mask.ip6, msk.ip_addr.ipv6_addr, 16);
-            break;
-        default:
-            throw std::logic_error("Invalid family");
-    }
-    return dst;
-}
-
 inline static sai_ip_prefix_t& subnet(sai_ip_prefix_t& dst, const sai_ip_prefix_t& src)
 {
     dst.addr_family = src.addr_family;


### PR DESCRIPTION
**What I did**
* Added a new version of the copy function that also takes the address mask as a parameter
* This new version is used in intfsorch in the Ip2MeRoute functions

**Why I did it**
* This is required in order to be able to correctly add subnet routes

**How I verified it**
* Verified in system test

**Details if related**
