### PR TITLE
[orchagent] Change version of the copy function used in intfsorch (al…

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1155,7 +1155,7 @@ void IntfsOrch::addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix)
     sai_route_entry_t unicast_route_entry;
     unicast_route_entry.switch_id = gSwitchId;
     unicast_route_entry.vr_id = vrf_id;
-    copy(unicast_route_entry.destination, ip_prefix.getIp());
+    copy(unicast_route_entry.destination, ip_prefix);
 
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
@@ -1178,7 +1178,7 @@ void IntfsOrch::addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix)
         throw runtime_error("Failed to create IP2me route.");
     }
 
-    SWSS_LOG_NOTICE("Create IP2me route ip:%s", ip_prefix.getIp().to_string().c_str());
+    SWSS_LOG_NOTICE("Create IP2me route ip:%s mask:%s", ip_prefix.getIp().to_string().c_str(), ip_prefix.getMask().to_string().c_str());
 
     if (unicast_route_entry.destination.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
     {
@@ -1195,7 +1195,7 @@ void IntfsOrch::removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_pref
     sai_route_entry_t unicast_route_entry;
     unicast_route_entry.switch_id = gSwitchId;
     unicast_route_entry.vr_id = vrf_id;
-    copy(unicast_route_entry.destination, ip_prefix.getIp());
+    copy(unicast_route_entry.destination, ip_prefix);
 
     sai_status_t status = sai_route_api->remove_route_entry(&unicast_route_entry);
     if (status != SAI_STATUS_SUCCESS)
@@ -1204,7 +1204,7 @@ void IntfsOrch::removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_pref
         throw runtime_error("Failed to remove IP2me route.");
     }
 
-    SWSS_LOG_NOTICE("Remove packet action trap route ip:%s", ip_prefix.getIp().to_string().c_str());
+    SWSS_LOG_NOTICE("Remove packet action trap route ip:%s, mask:%s", ip_prefix.getIp().to_string().c_str(), ip_prefix.getMask().to_string().c_str());
 
     if (unicast_route_entry.destination.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
     {

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -25,7 +25,7 @@ inline static sai_ip_address_t& copy(sai_ip_address_t& dst, const IpAddress& src
             break;
         case AF_INET6:
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
-            memcpy(dst.addr.ip6, sip.ip_addr.ipv6_addr, 16);
+            memcpy(dst.addr.ip6, sip.ip_addr.ipv6_addr, sizeof(dst.addr.ip6));
             break;
         default:
             throw std::logic_error("Invalid family");
@@ -46,8 +46,8 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpPrefix& src)
             break;
         case AF_INET6:
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
-            memcpy(dst.addr.ip6, ia.ip_addr.ipv6_addr, 16);
-            memcpy(dst.mask.ip6, ma.ip_addr.ipv6_addr, 16);
+            memcpy(dst.addr.ip6, ia.ip_addr.ipv6_addr, sizeof(dst.addr.ip6));
+            memcpy(dst.mask.ip6, ma.ip_addr.ipv6_addr, sizeof(dst.mask.ip6));
             break;
         default:
             throw std::logic_error("Invalid family");
@@ -67,8 +67,8 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src)
             break;
         case AF_INET6:
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV6;
-            memcpy(dst.addr.ip6, sip.ip_addr.ipv6_addr, 16);
-            memset(dst.mask.ip6, 0xFF, 16);
+            memcpy(dst.addr.ip6, sip.ip_addr.ipv6_addr, sizeof(dst.addr.ip6));
+            memset(dst.mask.ip6, 0xFF, sizeof(dst.mask.ip6));
             break;
         default:
             throw std::logic_error("Invalid family");
@@ -86,7 +86,7 @@ inline static sai_ip_prefix_t& subnet(sai_ip_prefix_t& dst, const sai_ip_prefix_
             dst.mask.ip4 = src.mask.ip4;
             break;
         case SAI_IP_ADDR_FAMILY_IPV6:
-            for (size_t i = 0; i < 16; i++)
+            for (size_t i = 0; i < sizeof(dst.addr.ip6); i++)
             {
                 dst.addr.ip6[i] = src.addr.ip6[i] & src.mask.ip6[i];
                 dst.mask.ip6[i] = src.mask.ip6[i];


### PR DESCRIPTION
**What I did**

* Change the version of the copy() function used in IP2Me intfsorch functions to take the address mask into account

**Why I did it**

* This is required in order to be able to correctly add subnet routes

**How I verified it**

* Verified in system test.
* No UTs affected